### PR TITLE
Test suite bounds and GHC 8 support

### DIFF
--- a/semilattices.cabal
+++ b/semilattices.cabal
@@ -34,9 +34,9 @@ test-suite doctests
   main-is:             Doctests.hs
   default-language:    Haskell2010
   build-depends:       base
-                     , doctest
-                     , QuickCheck
-                     , quickcheck-instances
+                     , doctest >= 0.7 && < 1.0
+                     , QuickCheck >= 2.7 && < 2.12
+                     , quickcheck-instances == 0.3.*
 
 source-repository head
   type:     git

--- a/semilattices.cabal
+++ b/semilattices.cabal
@@ -20,7 +20,7 @@ library
                      , Data.Semilattice.Order
                      , Data.Semilattice.Tumble
                      , Data.Semilattice.Upper
-  build-depends:       base >=4.10 && <4.12
+  build-depends:       base >=4.9 && <4.12
                      , containers >=0.5 && <0.6
                      , hashable >=1.2 && <1.3
                      , unordered-containers >=0.2 && <0.3

--- a/src/Data/Semilattice/Lower.hs
+++ b/src/Data/Semilattice/Lower.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DefaultSignatures, PolyKinds, TypeFamilies, TypeOperators #-}
+{-# LANGUAGE CPP, DefaultSignatures, PolyKinds, TypeFamilies, TypeOperators #-}
 -- | Lower bounds, related to 'Bounded', 'Join', 'Meet', and 'Ord'.
 module Data.Semilattice.Lower where
 
@@ -138,7 +138,9 @@ instance Coercible a b => Lower (Coercion a b)
 
 -- Data.Type.Equality
 instance (a ~ b) => Lower (a :~: b)
+#if MIN_VERSION_base(4,10,0)
 instance (a ~~ b) => Lower (a :~~: b)
+#endif
 
 -- Data.Word
 instance Lower Word8
@@ -155,7 +157,7 @@ instance Lower CSigAtomic
 instance Lower CWchar
 instance Lower CSize
 instance Lower CPtrdiff
-instance Lower CBool
+
 instance Lower CULLong
 instance Lower CLLong
 instance Lower CULong
@@ -167,6 +169,10 @@ instance Lower CShort
 instance Lower CUChar
 instance Lower CSChar
 instance Lower CChar
+
+#if MIN_VERSION_base(4,10,0)
+instance Lower CBool
+#endif
 
 -- Foreign.Ptr
 instance Lower IntPtr
@@ -180,13 +186,6 @@ instance Lower Associativity
 
 -- System.Posix.Types
 instance Lower Fd
-instance Lower CKey
-instance Lower CId
-instance Lower CFsFilCnt
-instance Lower CFsBlkCnt
-instance Lower CClockId
-instance Lower CBlkCnt
-instance Lower CBlkSize
 instance Lower CRLim
 instance Lower CTcflag
 instance Lower CUid
@@ -198,6 +197,16 @@ instance Lower COff
 instance Lower CMode
 instance Lower CIno
 instance Lower CDev
+
+#if MIN_VERSION_base(4,10,0)
+instance Lower CKey
+instance Lower CId
+instance Lower CFsFilCnt
+instance Lower CFsBlkCnt
+instance Lower CClockId
+instance Lower CBlkCnt
+instance Lower CBlkSize
+#endif
 
 -- containers
 instance Lower (IntMap a) where lowerBound = IntMap.empty

--- a/src/Data/Semilattice/Upper.hs
+++ b/src/Data/Semilattice/Upper.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DefaultSignatures, PolyKinds, TypeFamilies, TypeOperators #-}
+{-# LANGUAGE CPP, DefaultSignatures, PolyKinds, TypeFamilies, TypeOperators #-}
 -- | Upper bounds, related to 'Bounded', 'Join', 'Meet', and 'Ord'.
 module Data.Semilattice.Upper where
 
@@ -129,7 +129,9 @@ instance Coercible a b => Upper (Coercion a b)
 
 -- Data.Type.Equality
 instance (a ~ b) => Upper (a :~: b)
+#if MIN_VERSION_base(4,10,0)
 instance (a ~~ b) => Upper (a :~~: b)
+#endif
 
 -- Data.Word
 instance Upper Word8
@@ -146,7 +148,6 @@ instance Upper CSigAtomic
 instance Upper CWchar
 instance Upper CSize
 instance Upper CPtrdiff
-instance Upper CBool
 instance Upper CULLong
 instance Upper CLLong
 instance Upper CULong
@@ -158,6 +159,10 @@ instance Upper CShort
 instance Upper CUChar
 instance Upper CSChar
 instance Upper CChar
+
+#if MIN_VERSION_base(4,10,0)
+instance Upper CBool
+#endif
 
 -- Foreign.Ptr
 instance Upper IntPtr
@@ -171,13 +176,6 @@ instance Upper Associativity
 
 -- System.Posix.Types
 instance Upper Fd
-instance Upper CKey
-instance Upper CId
-instance Upper CFsFilCnt
-instance Upper CFsBlkCnt
-instance Upper CClockId
-instance Upper CBlkCnt
-instance Upper CBlkSize
 instance Upper CRLim
 instance Upper CTcflag
 instance Upper CUid
@@ -190,6 +188,15 @@ instance Upper CMode
 instance Upper CIno
 instance Upper CDev
 
+#if MIN_VERSION_base(4,10,0)
+instance Upper CKey
+instance Upper CId
+instance Upper CFsFilCnt
+instance Upper CFsBlkCnt
+instance Upper CClockId
+instance Upper CBlkCnt
+instance Upper CBlkSize
+#endif
 
 -- $setup
 -- >>> import Data.Semilattice.Join


### PR DESCRIPTION
Hi Rob!

- Adds bounds to the test stanza. The `doctest` lower bound might be too low for your liking, not sure
- Add necessary CPP to build against `base-4.9` (GHC 8.0 family)

With these changes I've got local build+tests passing for GHC 8.0.2 and 8.2.2 using the Cabal solver.

Let me know if the CPP is unwelcome and I'll revert it :)