### PR TITLE
Upper: fix typo in laws

### DIFF
--- a/src/Data/Semilattice/Upper.hs
+++ b/src/Data/Semilattice/Upper.hs
@@ -31,7 +31,7 @@ import System.Posix.Types
 --   If @s@ is a 'Meet' semilattice, 'upperBound' must be the identity of '/\':
 --
 -- @
--- 'upperBound' '\/' a = a
+-- 'upperBound' '/\' a = a
 -- @
 --
 --   If @s@ is a 'Join' semilattice, 'upperBound' must be the absorbing element of '\/':


### PR DESCRIPTION
To find it I just scrolled through two tabs:

![semilattice-typo](https://user-images.githubusercontent.com/624072/41498211-e71d35d0-7167-11e8-9ffa-07b7c9dfc8da.gif)

:-)

Also double checked with comments in `Meet.hs`:

> Additionally, if `s` has an `Upper` bound, then `upperBound` must be its identity:
> 
>     upperBound /\ a = a
>     a /\ upperBound = a