### PR TITLE
Define a Lower instance for Seq

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+# 0.0.0.2
+
+Add a `Lower` instance for `Data.Sequence.Seq`.
+
 # 0.0.0.1
 
 Add `Lower` instances for some `Data.Monoid` types.

--- a/semilattices.cabal
+++ b/semilattices.cabal
@@ -1,5 +1,5 @@
 name:                semilattices
-version:             0.0.0.1
+version:             0.0.0.2
 synopsis:            Semilattices
 description:         Join- and meet-semilattices, with optional upper and lower bounds, and a variety of instances for each.
 homepage:            https://github.com/robrix/semilattices

--- a/src/Data/Semilattice/Lower.hs
+++ b/src/Data/Semilattice/Lower.hs
@@ -15,6 +15,7 @@ import Data.Map as Map
 import Data.Monoid as Monoid
 import Data.Proxy
 import Data.Semigroup as Semigroup
+import Data.Sequence as Seq
 import Data.Set as Set
 import Data.Type.Coercion
 import Data.Type.Equality
@@ -215,6 +216,7 @@ instance Lower CBlkSize
 instance Lower (IntMap a) where lowerBound = IntMap.empty
 instance Lower IntSet where lowerBound = IntSet.empty
 instance Lower (Map k a) where lowerBound = Map.empty
+instance Lower (Seq a) where lowerBound = Seq.empty
 instance Lower (Set a) where lowerBound = Set.empty
 
 -- unordered-containers


### PR DESCRIPTION
This PR defines a `Lower` instance for `Seq` from `containers`.