### PR TITLE
Loosen QuickCheck upper bounds.

### DIFF
--- a/semilattices.cabal
+++ b/semilattices.cabal
@@ -47,7 +47,7 @@ test-suite doctests
   default-language:    Haskell2010
   build-depends:       base
                      , doctest >= 0.7 && < 1.0
-                     , QuickCheck >= 2.7 && < 2.12
+                     , QuickCheck >= 2.7 && < 3
                      , quickcheck-instances == 0.3.*
 
 source-repository head


### PR DESCRIPTION
New LTS versions are coming with QuickCheck 2.14.