### PR TITLE
Fix compilation on GHCJS.

### DIFF
--- a/semilattices.cabal
+++ b/semilattices.cabal
@@ -16,9 +16,10 @@ extra-source-files:
   README.md
   ChangeLog.md
 
-tested-with:         GHC == 8.2.2
-                   , GHC == 8.4.4
-                   , GHC == 8.6.2
+tested-with:         GHC   == 8.2.2
+                   , GHC   == 8.4.4
+                   , GHC   == 8.6.2
+                   , GHCJS == 8.4.0
 
 library
   exposed-modules:     Data.Semilattice.Bound

--- a/src/Data/Semilattice/Lower.hs
+++ b/src/Data/Semilattice/Lower.hs
@@ -207,7 +207,9 @@ instance Lower CKey
 instance Lower CId
 instance Lower CFsFilCnt
 instance Lower CFsBlkCnt
+#ifdef HTYPE_CLOCKID_T
 instance Lower CClockId
+#endif
 instance Lower CBlkCnt
 instance Lower CBlkSize
 #endif

--- a/src/Data/Semilattice/Upper.hs
+++ b/src/Data/Semilattice/Upper.hs
@@ -193,7 +193,9 @@ instance Upper CKey
 instance Upper CId
 instance Upper CFsFilCnt
 instance Upper CFsBlkCnt
+#ifdef HTYPE_CLOCKID_T
 instance Upper CClockId
+#endif
 instance Upper CBlkCnt
 instance Upper CBlkSize
 #endif


### PR DESCRIPTION
The CClockId type is not available on JS, so we #ifdef it out. If
anyone has any more elegant ideas to detect whether we're on GHCJS, I
am all ears: the `__GHCJS__` and `ghcjs_HOST_OS` defines did not seem
to yield the desired results.